### PR TITLE
scripts/program/disassemble: add 'no-aliases' option to objdump

### DIFF
--- a/scripts/program/common/02_disassemble.bat
+++ b/scripts/program/common/02_disassemble.bat
@@ -1,2 +1,2 @@
 
-mips-mti-elf-objdump -D program.elf > program.dis
+mips-mti-elf-objdump -M 'no-aliases' -D program.elf > program.dis

--- a/scripts/program/common/02_disassemble.sh
+++ b/scripts/program/common/02_disassemble.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-mips-mti-elf-objdump -D program.elf > program.dis
+mips-mti-elf-objdump -M 'no-aliases' -D program.elf > program.dis


### PR DESCRIPTION
* According to 'objdump' documentation, 'no-aliases' option
  enables 'objdump' to print only 'raw' instructions mnemonics,
  insted of pseudo instructions mnemonics.

  In context of CPU implementation process it seems more
  convenient to analyze 'raw' instructions of executable binary
  to clearly see what instructions CPU will really execute and
  what the instrctuions should to be implemented to support
  the specific pseudo instruction.

  For example a beginner may get confused when he sees usage of
  'move' instruction, but do not sees it's implementation in the
  CPU code.

Signed-off-by: Oleg Lyovin <olegartys@gmail.com>