### PR TITLE
remove -novopt

### DIFF
--- a/program/00_counter/03_simulate_with_modelsim.sh
+++ b/program/00_counter/03_simulate_with_modelsim.sh
@@ -6,6 +6,6 @@ cd sim
 
 cp ../*.hex .
 
-vsim -novopt -do ../modelsim_script.tcl
+vsim -do ../modelsim_script.tcl
 
 cd ..

--- a/program/01_fibonacci/03_simulate_with_modelsim.sh
+++ b/program/01_fibonacci/03_simulate_with_modelsim.sh
@@ -6,6 +6,6 @@ cd sim
 
 cp ../*.hex .
 
-vsim -novopt -do ../modelsim_script.tcl
+vsim -do ../modelsim_script.tcl
 
 cd ..

--- a/program/02_sqrt/03_simulate_with_modelsim.sh
+++ b/program/02_sqrt/03_simulate_with_modelsim.sh
@@ -6,6 +6,6 @@ cd sim
 
 cp ../*.hex .
 
-vsim -novopt -do ../modelsim_script.tcl
+vsim -do ../modelsim_script.tcl
 
 cd ..

--- a/scripts/program/common/03_simulate_with_modelsim.bat
+++ b/scripts/program/common/03_simulate_with_modelsim.bat
@@ -4,6 +4,6 @@ cd sim
 
 copy ..\*.hex .
 
-vsim -novopt -do ../modelsim_script.tcl
+vsim -do ../modelsim_script.tcl
 
 cd ..

--- a/scripts/program/common/03_simulate_with_modelsim.sh
+++ b/scripts/program/common/03_simulate_with_modelsim.sh
@@ -6,6 +6,6 @@ cd sim
 
 cp ../*.hex .
 
-vsim -novopt -do ../modelsim_script.tcl
+vsim -do ../modelsim_script.tcl
 
 cd ..


### PR DESCRIPTION
> * The -novopt command line switch will be deprecated in the next major release 10.7 following normal deprecation process:
>          + The -novopt switch will be accepted in 10.7 with a deprecation warning message.
>          + In 10.8 or a subsequent release, the -novopt switch will be disabled and cause error messages to be emitted.

https://www.intel.com/content/dam/altera-www/global/en_US/others/download/os-support/release-notes-10-6d.txt
